### PR TITLE
fix: version is a list and not a single element anymore

### DIFF
--- a/relaton/serializers/bibxml/anchor.py
+++ b/relaton/serializers/bibxml/anchor.py
@@ -39,7 +39,7 @@ def get_suitable_anchor(item: BibliographicItem) -> str:
             return format_internet_draft_anchor(
                 docid.id,
                 versioned=True
-                    if (item.version and item.version.draft)
+                    if any((v and v.draft) for v in item.version)
                     else False)
         elif docid.scope == 'anchor':
             return docid.id

--- a/relaton/tests/test_serializers.py
+++ b/relaton/tests/test_serializers.py
@@ -68,7 +68,7 @@ class SerializerTestCase(TestCase):
             "date": [{"type": "published", "value": "1996-02"}],
             "abstract": [{"content": "abstract_content"}],
             "series": [{"title": ["IEEE P2740/D-6.5 2020-08"], "type": "IEEE"}],
-            "version": {"draft": True},
+            "version": [{"draft": True}],
         }
         self.bibitem_reference = BibliographicItem(**self.bibitem_reference_data)
 


### PR DESCRIPTION
Fixes for what https://github.com/relaton/relaton-py/commit/4faf46d161d8a08af8497ad4d03ff6090cfb16c4 broke (tests and `get_suitable_anchor`).