### PR TITLE
Use `IANA` (abbreviation) instead of `Internet Assigned Numbers Authority`

### DIFF
--- a/relaton/serializers/bibxml/authors.py
+++ b/relaton/serializers/bibxml/authors.py
@@ -62,8 +62,8 @@ def create_author(contributor: Contributor) -> Element:
 
     if org is not None:
         # Organization
-        if org.abbreviation == "IANA":
-            org_el = E.organization("IANA")
+        if org.abbreviation == 'IANA' or org.name == 'Internet Assigned Numbers Authority':
+            org_el = E.organization('IANA')
         else:
             org_el = E.organization(as_list(org.name)[0])
 

--- a/relaton/serializers/bibxml/authors.py
+++ b/relaton/serializers/bibxml/authors.py
@@ -62,10 +62,13 @@ def create_author(contributor: Contributor) -> Element:
 
     if org is not None:
         # Organization
-        org_el = E.organization(as_list(org.name)[0])
+        if org.abbreviation == "IANA":
+            org_el = E.organization("IANA")
+        else:
+            org_el = E.organization(as_list(org.name)[0])
 
-        if org.abbreviation:
-            org_el.set('abbrev', org.abbreviation)
+            if org.abbreviation:
+                org_el.set('abbrev', org.abbreviation)
 
         author_el.append(org_el)
 

--- a/relaton/tests/test_serializers.py
+++ b/relaton/tests/test_serializers.py
@@ -1,3 +1,4 @@
+# type: ignore
 import os
 from copy import copy
 from io import StringIO
@@ -341,6 +342,24 @@ class SerializerTestCase(TestCase):
         with self.assertRaises(ValueError):
             create_author(contributor_organization)
             create_author(contributor_person)
+
+    def test_create_author_IANA_entries(self):
+        """
+        create_author should remove the abbreviation
+        property for Internet Assigned Numbers Authority
+        entries and abbreviate its value to IANA.
+        <organization>IANA</organization>
+        """
+        contributor_organization_data = {
+            "organization": {
+                "name": "Internet Assigned Numbers Authority",
+                "abbreviation": "IANA",
+            },
+            "role": "publisher",
+        }
+        author_organization = create_author(Contributor(**contributor_organization_data))
+        self.assertEqual(author_organization.tag, "author")
+        self.assertEqual(author_organization.xpath("//organization")[0], "IANA")
 
     def test_get_suitable_anchor(self):
         """

--- a/relaton/tests/test_serializers.py
+++ b/relaton/tests/test_serializers.py
@@ -361,6 +361,22 @@ class SerializerTestCase(TestCase):
         self.assertEqual(author_organization.tag, "author")
         self.assertEqual(author_organization.xpath("//organization")[0], "IANA")
 
+    def test_create_author_non_IANA_entries(self):
+        """
+        create_author should return the full-length name
+        of the organization within the <organization> tag
+        """
+        organization_name = "Any Organization"
+        contributor_organization_data = {
+            "organization": {
+                "name": organization_name,
+            },
+            "role": "publisher",
+        }
+        author_organization = create_author(Contributor(**contributor_organization_data))
+        self.assertEqual(author_organization.tag, "author")
+        self.assertEqual(author_organization.xpath("//organization")[0], organization_name)
+
     def test_get_suitable_anchor(self):
         """
         get_suitable_anchor should return the correct anchor value


### PR DESCRIPTION
Internet Assigned Numbers Authority entries should be formatted as:

```
<reference anchor="NAME" target="URL">
  <front>
    <title>Registry Name</title>
    <author>
      <organization>IANA</organization>
    </author>
  </front>
</reference>
```

instead of 

```
<reference anchor="NAME" target="URL">
  <front>
    <title>Registry Name</title>
    <author>
      <organization abbreviation="IANA">Internet Assigned Numbers Authority</organization>
    </author>
  </front>
</reference>
```

as it would be for canonical serialisation of the organization tags.