### PR TITLE
Generate lockfile

### DIFF
--- a/.github/workflows/generate-lockfile.yml
+++ b/.github/workflows/generate-lockfile.yml
@@ -1,0 +1,27 @@
+name: Generate Lockfile
+
+on:
+  workflow_dispatch:
+  
+jobs:
+  generate-lockfile:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: generate-lockfile
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.1
+
+      - run: |
+          bundle config unset --local deployment
+          bundle install
+      - run: less Gemfile.lock
+      - run: |
+          git pull origin
+          git add Gemfile.lock
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git diff --quiet && git diff --staged --quiet || (git commit -m 'add lockfile' && git push)

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem 'relaton-cli', "=1.15.1"


### PR DESCRIPTION
This branch can be used to manually generate the Gemfile.lock. First, copy latest Gemfile from https://github.com/ietf-tools/bibxml-service, then run this workflow and copy the generated Gemfile.lock into the destination folder.

DO NOT MERGE this branch. Gemfile and Gemfile.lock should not be included as part of this repository. 